### PR TITLE
[fix] Adding reconfigure opt to meson

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ if [ $EUID != 0 ]; then
    exit 1
 fi
 
-meson build --buildtype=release --prefix=$PREFIX
+meson --reconfigure build --buildtype=release --prefix=$PREFIX
 ninja -v -C build
 ninja -v -C build install
 chmod 4011 $PREFIX/bin/ostree-compliance-mode


### PR DESCRIPTION
After failed build, assume building on ostree image with empty PREFIX env_var, reconfigure is needed to finish with success once second run with non empty PREFIX is set